### PR TITLE
add missing packages to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ Run with `--help` for additional options
 Requirements
 ------------
 
+You will need the following packages (install w/ apt, homebrew, or your
+friendly neighborhood package manager):
+
+* libffi-dev
+* libxml2-dev
+* libxslt-dev
+
+And these Python package dependencies:
+
 - mitmproxy
 - selenium
 - pyvirtualdisplay


### PR DESCRIPTION
I ran into errors with missing packages while trying to install the required Python packages (listed in the README) with pip. I added a note to the README in case other people have the same problem.
